### PR TITLE
Fix docker test

### DIFF
--- a/test/run-heimdal.sh
+++ b/test/run-heimdal.sh
@@ -12,7 +12,7 @@ REALM_NAME="XAMPLE.TEST" \
 DOMAIN_NAME="xample.test" \
 USER_NAME="testuser" \
 USER_PASSWORD="P@ssword!" \
-CLIENT_IN_CONTAINER="" \
+CLIENT_IN_CONTAINER="yes" \
         ./run.sh
 
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -5,11 +5,11 @@
 result="NOT OK FAILED"
 
 # boot2docker doesn't seem to like /tmp so use the home direcotry for the build
-BASE_DIR=$(cd .. && pwd)
+BASE_DIR="$(cd .. && pwd)"
 export TEST_DIR="$HOME/tmp/$(uuidgen)"
-mkdir -p $TEST_DIR
-cp -R $BASE_DIR $TEST_DIR
-DOCKER_DIR=$TEST_DIR/gssapi/test/docker
+mkdir -p -- "$TEST_DIR"
+cp -R "$BASE_DIR" "$TEST_DIR"
+DOCKER_DIR="$TEST_DIR/gssapi/test/docker"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
         DOCKER=docker
@@ -18,22 +18,22 @@ else
 fi
 
 function log() {
-	>&2 /bin/echo "go-gssapi-test: $*"
+        printf "go-gssapi-test: %s\n" "$*" >&2
 }
 
 function cleanup_containers() {
-	log "Clean up running containers"
-	running=`$DOCKER ps --all | grep 'go-gssapi-test' | awk '{print $1}'`
-	if [[ "$running" != "" ]]; then
-		echo $running | xargs $DOCKER stop >/dev/null
-		echo $running | xargs $DOCKER rm >/dev/null
-	fi
+        log "Clean up running containers"
+        running=`$DOCKER ps --all | grep 'go-gssapi-test' | awk '{print $1}'`
+        if [[ "$running" != "" ]]; then
+                echo $running | xargs $DOCKER stop >/dev/null
+                echo $running | xargs $DOCKER rm >/dev/null
+        fi
 }
 
 function cleanup() {
         set +e
 
-        if [[ "${EXT_KDC_HOST}" == "" ]]; then
+        if [[ "${EXT_KDC_HOST:-}" == "" ]]; then
                 log "kdc logs:
 
 "
@@ -43,28 +43,28 @@ function cleanup() {
         log "service logs:
 
 "
-        if [[ "$SERVICE_LOG_FILTER" != "" ]]; then
+        if [[ "${SERVICE_LOG_FILTER:-}" != "" ]]; then
                 $DOCKER logs service 2>&1 | egrep -v "gssapi-sample:\t[0-9 /:]+ ACCESS "
         else
                 $DOCKER logs service 2>&1
         fi
 
-	cleanup_containers
+        cleanup_containers
 
-	log "Clean up build directory"
-	rm -rf $TEST_DIR
+        log "Clean up build directory"
+        rm -rf -- "${TEST_DIR:?}"
 
         log $result
 }
 
 function build_image() {
-        comp=$1
-        name=$2
-        func=$3
+        comp="$1"
+        name="$2"
+        func="$3"
         img="go-gssapi-test-${name}"
-        image=$($DOCKER images --quiet ${img})
+        image="$($DOCKER images --quiet ${img})"
 
-        if [[ "$REUSE_DOCKER_IMAGES" != "" && "$image" != "" ]]; then
+        if [[ "${REUSE_DOCKER_IMAGES:-}" != "" && "$image" != "" ]]; then
                 log "Reuse cached docker image ${img} ${image}"
         else
                 log "Build docker image ${img}"
@@ -76,17 +76,22 @@ function build_image() {
                         --rm \
                         --quiet \
                         --tag=${img} \
-                        $DOCKER_DIR/${comp}
+                        "$DOCKER_DIR/${comp}"
         fi
 }
 
+# Caveat: Quote characters in USER_PASSWORD may cause Severe Pain.
+#         Don't do that.
+#         This only has to handle Docker tests, not quite the Real World,
+#         so we can get away with this restriction.
+#
 function run_image() {
-        comp=$1
-        name=$2
-        options=$3
+        comp="$1"
+        name="$2"
+        options="$3"
         img="go-gssapi-test-${name}"
         log "Run docker image ${img}"
-	options="${options} \
+        options="${options} \
                 --hostname=${comp} \
                 --name=${comp} \
                 --env SERVICE_NAME=${SERVICE_NAME} \
@@ -94,13 +99,13 @@ function run_image() {
                 --env USER_PASSWORD=${USER_PASSWORD} \
                 --env REALM_NAME=${REALM_NAME} \
                 --env DOMAIN_NAME=${DOMAIN_NAME}"
-	$DOCKER run -P ${options} ${img}
+        $DOCKER run -P ${options} ${img}
 }
 
 function map_ports() {
-	comp=$1
-        port=$2
-        COMP=`echo $comp | tr '[:lower:]' '[:upper:]'`
+        comp="$1"
+        port="$2"
+        COMP="$(printf "%s\n" "$comp" | tr '[:lower:]' '[:upper:]')"
         if [[ "${OSTYPE}" == "darwin"* ]]; then
                 b2d_ip=$(boot2docker ip)
                 export ${COMP}_PORT_${port}_TCP_ADDR=${b2d_ip}
@@ -111,16 +116,16 @@ function map_ports() {
 }
 
 function wait_until_available() {
-        comp=$1
-        addr=$2
-        port=$3
+        comp="$1"
+        addr="$2"
+        port="$3"
 
-        i=1
+        let i=1
         while ! echo exit | nc $addr $port >/dev/null; do
                 echo "Waiting for $comp to start"
                 sleep 1
-                i=`expr $i + 1`
-                if [[ $i -gt 10 ]]; then
+                let i++
+                if (( i > 10 )); then
                        echo "Timed out waiting for ${comp} to start at ${addr}:${port}"
                        exit 1
                 fi
@@ -135,11 +140,11 @@ env_suffix=$(/bin/echo "${REALM_NAME}-${SERVICE_NAME}" | shasum | cut -f1 -d ' '
 
 # KDC
 if [[ "${EXT_KDC_HOST}" == "" ]]; then
-        cat $DOCKER_DIR/kdc/krb5.conf.template \
+        cat "$DOCKER_DIR/kdc/krb5.conf.template" \
                 | sed -e "s/KDC_ADDRESS/0.0.0.0:88/g" \
                 | sed -e "s/DOMAIN_NAME/${DOMAIN_NAME}/g" \
                 | sed -e "s/REALM_NAME/${REALM_NAME}/g" \
-                > $DOCKER_DIR/kdc/krb5.conf
+                > "$DOCKER_DIR/kdc/krb5.conf"
 
         build_image "kdc" "kdc-${env_suffix}" "" >/dev/null
         run_image "kdc" "kdc-${env_suffix}" "--detach" >/dev/null
@@ -151,14 +156,14 @@ fi
 wait_until_available "kdc" $KDC_PORT_88_TCP_ADDR $KDC_PORT_88_TCP_PORT
 
 function keytab_from_kdc() {
-        $DOCKER cp kdc:/etc/docker-kdc/krb5.keytab $DOCKER_DIR/service
+        $DOCKER cp kdc:/etc/docker-kdc/krb5.keytab "$DOCKER_DIR/service"
 }
 
 function keytab_from_options() {
-        cp ${KEYTAB_FILE} $DOCKER_DIR/service/krb5.keytab
+        cp "${KEYTAB_FILE}" "$DOCKER_DIR/service/krb5.keytab"
 }
 
-if [[ "${EXT_KDC_HOST}" == "" ]]; then
+if [[ "${EXT_KDC_HOST:-}" == "" ]]; then
         DOCKER_KDC_OPTS='--link=kdc:kdc'
         KEYTAB_FUNCTION='keytab_from_kdc'
 else
@@ -191,14 +196,14 @@ if [[ "$OSTYPE" != "darwin"* || "$CLIENT_IN_CONTAINER" != "" ]]; then
 else
         log "Run gssapi sample client on host"
         KRB5_CONFIG_TEMPLATE=${DOCKER_DIR}/client/krb5.conf.template \
-                DOMAIN_NAME=${DOMAIN_NAME} \
+                DOMAIN_NAME="${DOMAIN_NAME}" \
                 GSSAPI_PATH=/opt/local/lib/libgssapi_krb5.dylib \
-                KRB5_CONFIG=${TEST_DIR}/krb5.conf \
-                REALM_NAME=${REALM_NAME} \
-                SERVICE_NAME=${SERVICE_NAME} \
-                USER_NAME=${USER_NAME} \
-                USER_PASSWORD=${USER_PASSWORD} \
-                ${DOCKER_DIR}/client/entrypoint.sh
+                KRB5_CONFIG="${TEST_DIR}/krb5.conf" \
+                REALM_NAME="${REALM_NAME}" \
+                SERVICE_NAME="${SERVICE_NAME}" \
+                USER_NAME="${USER_NAME}" \
+                USER_PASSWORD="${USER_PASSWORD}" \
+                "${DOCKER_DIR}/client/entrypoint.sh"
 fi
 
 result="OK TEST PASSED"


### PR DESCRIPTION
@levb @alextoombs : we were running the entrypoint on the Mac box, using Mac kinit, which failed with only system kinit and polluted/stomped-on the kinit cache if another was present.  For a Docker test, force isolation completely with the advertised invocation wrapper.  That's all in `run-heimdal.sh`.

Also some robustness fixes to `run.sh` while I'm looking at it.