### PR TITLE
Test to use Go 1.5

### DIFF
--- a/test/docker/client/Dockerfile
+++ b/test/docker/client/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y install \
         libkrb5-dev \
         libsasl2-modules-gssapi-mit \
         wget
-RUN (cd /tmp && wget https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz && tar xvf go1.4.1.linux-amd64.tar.gz && mv go/ /opt)
+RUN (cd /tmp && wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz && tar xvf go1.5.linux-amd64.tar.gz && mv go/ /opt)
 ENV GOROOT="/opt/go"
 
 ADD krb5.conf.template /tmp/krb5.conf.template

--- a/test/docker/service/Dockerfile
+++ b/test/docker/service/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y install \
         libsasl2-modules-gssapi-mit \
         wget
 
-RUN (cd /tmp && wget https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz && tar xvf go1.4.1.linux-amd64.tar.gz && mv go/ /opt)
+RUN (cd /tmp && wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz && tar xvf go1.5.linux-amd64.tar.gz && mv go/ /opt)
 ENV GOROOT="/opt/go"
 ADD krb5.keytab /opt/go-gssapi-test-service/krb5.keytab
 ADD krb5.conf.template /tmp/krb5.conf.template


### PR DESCRIPTION
@philpennock @alextoombs please review, test result below

```
➜  test git:(golang-1-5) ✗ ./run-heimdal.sh
go-gssapi-test: Clean up running containers
go-gssapi-test: Build docker image go-gssapi-test-kdc-fcb7d6ccee943599cd6e5ff12f116f088e2c58dc
go-gssapi-test: Run docker image go-gssapi-test-kdc-fcb7d6ccee943599cd6e5ff12f116f088e2c58dc
go-gssapi-test: Build and unit-test gssapi on host
ok  	github.com/apcera/gssapi	0.058s
go-gssapi-test: Build docker image go-gssapi-test-service-fcb7d6ccee943599cd6e5ff12f116f088e2c58dc
go-gssapi-test: Run docker image go-gssapi-test-service-fcb7d6ccee943599cd6e5ff12f116f088e2c58dc
Waiting for service to start
Waiting for service to start
Waiting for service to start
Waiting for service to start
Waiting for service to start
go-gssapi-test: Build docker image go-gssapi-test-client
go-gssapi-test: Run docker image go-gssapi-test-client
Using default cache: /tmp/krb5cc_0
Using principal: testuser@XAMPLE.TEST
Authenticated to Kerberos v5
go-gssapi-test-client: Debug	2015/08/19 20:12:38 Loading "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2"
go-gssapi-test-client: Debug	2015/08/19 20:12:38 Config: {
  "DebugLog": true,
  "RunAsService": false,
  "ServiceName": "HTTP/auth.www.xample.test",
  "ServiceAddress": "172.17.0.6:80",
  "LibPath": "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2",
  "Krb5Config": "",
  "Krb5Ktname": "",
  "LoadDefault": 0
}
=== RUN   TestClientAccess
--- PASS: TestClientAccess (0.09s)
=== RUN   TestClientInquireContext
--- PASS: TestClientInquireContext (0.01s)
=== RUN   TestClientWrap
--- PASS: TestClientWrap (0.01s)
=== RUN   TestClientMIC
--- PASS: TestClientMIC (0.01s)
PASS
go-gssapi-test: kdc logs:


Max ticket life [1 day]:Max renewable life [1 week]:Principal expiration time [never]:Password expiration time [never]:Attributes []:Policy [default]:HTTP/auth.www.xample.test@XAMPLE.TEST's Password:
Verify password - HTTP/auth.www.xample.test@XAMPLE.TEST's Password:
Max ticket life [1 day]:Max renewable life [1 week]:Principal expiration time [never]:Password expiration time [never]:Attributes []:Policy [default]:testuser@XAMPLE.TEST's Password:
Verify password - testuser@XAMPLE.TEST's Password:
go-gssapi-test: service logs:


go-gssapi-test-service: Debug	2015/08/19 20:12:09 Loading "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2"
go-gssapi-test-service: Debug	2015/08/19 20:12:09 Config: {
  "DebugLog": true,
  "RunAsService": true,
  "ServiceName": "HTTP/auth.www.xample.test",
  "ServiceAddress": ":80",
  "LibPath": "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2",
  "Krb5Config": "/opt/go-gssapi-test-service/krb5.conf",
  "Krb5Ktname": "/opt/go-gssapi-test-service/krb5.keytab",
  "LoadDefault": 0
}
=== RUN   TestAcquireCredential
--- PASS: TestAcquireCredential (0.01s)
=== RUN   TestAddCredential
--- PASS: TestAddCredential (0.00s)
=== RUN   TestIndicateMechs
--- PASS: TestIndicateMechs (0.00s)
=== RUN   TestInquireMechsForName
--- PASS: TestInquireMechsForName (0.00s)
=== RUN   TestCanonicalizeName
--- PASS: TestCanonicalizeName (0.00s)
PASS
go-gssapi-test-service: Debug	2015/08/19 20:12:09 Starting service "HTTP/auth.www.xample.test"
go-gssapi-test-service: Debug	2015/08/19 20:12:09 Acquired credentials using /opt/go-gssapi-test-service/krb5.keytab
go-gssapi-test-service: Info	2015/08/19 20:12:38 200 "GET" "/access/" "OK"
go-gssapi-test-service: Info	2015/08/19 20:12:38 200 "GET" "/inquire_context/" "OK"
go-gssapi-test-service: Info	2015/08/19 20:12:38 200 "POST" "/unwrap/" "OK"
go-gssapi-test-service: Info	2015/08/19 20:12:38 200 "POST" "/verify_mic/" "OK"
go-gssapi-test: Clean up running containers
go-gssapi-test: Clean up build directory
go-gssapi-test: OK TEST PASSED
```