### PR TITLE
elimination of boot2docker

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -107,7 +107,7 @@ function map_ports() {
         port="$2"
         COMP="$(printf "%s\n" "$comp" | tr '[:lower:]' '[:upper:]')"
         if [[ "${OSTYPE}" == "darwin"* ]]; then
-                b2d_ip=$(boot2docker ip)
+                b2d_ip=$(docker-machine ip default)
                 export ${COMP}_PORT_${port}_TCP_ADDR=${b2d_ip}
         else
                 export ${COMP}_PORT_${port}_TCP_ADDR=127.0.0.1


### PR DESCRIPTION
test/run.sh needs boot2docker to work correctly. As boot2docker is obsolete, I've replaced it with docker-machine. However please consider if change is ok in wider context. Thx.