### PR TITLE
travis: add Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.4
   - 1.5
+  - 1.6
   - tip
 
 sudo: required


### PR DESCRIPTION
Following the official release of Go 1.6 in February, trigger unit
tests against Go 1.6 as well as tip.

@levb @philpennock @lloydde 