### PR TITLE
README: add Coveralls, report card, license images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gssapi
 
-[![Build Status](https://travis-ci.org/apcera/gssapi.svg?branch=master)](https://travis-ci.org/apcera/gssapi)
+[![License][License-Image]][License-Url] [![ReportCard][ReportCard-Image]][ReportCard-Url] [![Build][Build-Status-Image]][Build-Status-Url] [![Coverage][Coverage-Image]][Coverage-Url]
 
 The gssapi package is a Golang wrapper around [RFC 2743](https://www.ietf.org/rfc/rfc2743.txt),
 the Generic Security Services Application Programming Interface. (GSSAPI)
@@ -70,3 +70,12 @@ We definitely cannot authenticate with:
 
 - Windows clients (because Windows uses SSPI instead of GSSAPI as the library
   interface)
+
+[License-Url]: https://opensource.org/licenses/Apache-2.0
+[License-Image]: https://img.shields.io/hexpm/l/plug.svg
+[Build-Status-Url]: http://travis-ci.org/apcera/gssapi
+[Build-Status-Image]: https://travis-ci.org/apcera/gssapi.svg?branch=master
+[Coverage-Url]: https://coveralls.io/r/apcera/gssapi?branch=master
+[Coverage-image]: https://img.shields.io/coveralls/apcera/gssapi.svg?branch=master
+[ReportCard-Url]: http://goreportcard.com/report/github.com/apcera/gssapi
+[ReportCard-Image]: http://goreportcard.com/badge/github.com/apcera/gssapi


### PR DESCRIPTION
Also, consolidate all links into one location at the bottom of the file,
referenced in-line together. Inspired by the `nats-io/gnatsd` layout.

FYI PR