### PR TITLE
SPNEGO: Support mutual authentication

### DIFF
--- a/spnego/spnego_server.go
+++ b/spnego/spnego_server.go
@@ -5,7 +5,9 @@
 package spnego
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/apcera/gssapi"
@@ -89,6 +91,13 @@ func (k KerberizedServer) Negotiate(cred *gssapi.CredId, inHeader, outHeader htt
 			cred, inputToken, k.GSS_C_NO_CHANNEL_BINDINGS)
 	if err != nil {
 		return "", http.StatusBadRequest, err
+	}
+	if outputToken.Length() > 0 {
+		outHeader.Add(
+			"WWW-Authenticate",
+			fmt.Sprintf(
+				"Negotiate %s",
+				base64.StdEncoding.EncodeToString(outputToken.Bytes())))
 	}
 	delegatedCredHandle.Release()
 	ctx.DeleteSecContext()


### PR DESCRIPTION
If an output token is generated, it should be base64 encoded and added
to the HTTP response as a WWW-Authenticate header. This allows the
client to authenticate the server in the case where it has requested
mutual authentication.

From RFC4559 (SPNEGO-based Kerberos and NTLM HTTP Authentication in
Microsoft Windows) section 4.1:

    A status code 200 status response can also carry a
    "WWW-Authenticate" response header containing the final leg of an
    authentication.  In this case, the gssapi-data will be present.
    Before using the contents of the response, the gssapi-data should be
    processed by gss_init_security_context to determine the state of the
    security context.  If this function indicates success, the response
    can be used by the application.  Otherwise, an appropriate action,
    based on the authentication status, should be taken.

    For example, the authentication could have failed on the final leg
    if mutual authentication was requested and the server was not able
    to prove its identity.  In this case, the returned results are
    suspect. It is not always possible to mutually authenticate the
    server before the HTTP operation.  POST methods are in this
    category.