### PR TITLE
Support gss_localname

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -155,6 +155,7 @@ type ftable struct {
 	Fp_gss_export_name            unsafe.Pointer
 	Fp_gss_inquire_mechs_for_name unsafe.Pointer
 	Fp_gss_inquire_names_for_mech unsafe.Pointer
+	Fp_gss_localname              unsafe.Pointer
 	Fp_gss_release_name           unsafe.Pointer
 
 	// oid_set.go


### PR DESCRIPTION
Provides a mechanism to call out to gss_localname to translate an
authenticated name (principal) to a local name (e.g. username).

I've confirmed that this works against mit-krb5 1.15 (the commit which added it is from 7 years ago: https://github.com/krb5/krb5/commit/fe12e6f6da58abc3cc3e2d30d3925259ad1fbf6a) and I see that gss_localname was added to heimdal as of 7.1.